### PR TITLE
Hotfix/bitcode

### DIFF
--- a/Example/SensorbergSDK Demo.xcodeproj/project.pbxproj
+++ b/Example/SensorbergSDK Demo.xcodeproj/project.pbxproj
@@ -39,7 +39,6 @@
 		50C0E1A119C093A600B6E21F /* SBSDKDetectedBeaconsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SBSDKDetectedBeaconsViewController.h; sourceTree = "<group>"; };
 		50C0E1A219C093A600B6E21F /* SBSDKDetectedBeaconsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SBSDKDetectedBeaconsViewController.m; sourceTree = "<group>"; };
 		50E318AC19E2F3C100B49973 /* SensorbergSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SensorbergSDK.framework; path = ../SensorbergSDK.framework; sourceTree = "<group>"; };
-		50E318AE19E3DE1600B49973 /* SensorbergSDK.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = SensorbergSDK.xcconfig; path = ../../SensorbergSDK.xcconfig; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* SB-SDK-Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SB-SDK-Demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		6003F58F195388D20070C39A /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -150,7 +149,6 @@
 		6003F594195388D20070C39A /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
-				50E318AE19E3DE1600B49973 /* SensorbergSDK.xcconfig */,
 				5004922219BF4156009404BC /* Info.plist */,
 				5004922319BF4156009404BC /* prefix.pch */,
 				6003F599195388D20070C39A /* main.m */,
@@ -310,7 +308,6 @@
 /* Begin XCBuildConfiguration section */
 		6003F5BD195388D20070C39A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 50E318AE19E3DE1600B49973 /* SensorbergSDK.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -350,7 +347,6 @@
 		};
 		6003F5BE195388D20070C39A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 50E318AE19E3DE1600B49973 /* SensorbergSDK.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";

--- a/SensorbergSDK.podspec
+++ b/SensorbergSDK.podspec
@@ -28,5 +28,7 @@ Pod::Spec.new do |s|
   s.xcconfig                = { "OTHER_LDFLAGS" => "$(inherited) -ObjC -read_only_relocs suppress",
                                 "GCC_PREPROCESSOR_DEFINITIONS" => %{$(inherited) SENSORBERGSDK_VERSION="@\\"#{s.version}\\""},
                                 "CLANG_ENABLE_MODULES" => "YES",
-                                "CLANG_MODULES_AUTOLINK" => "YES" }
+                                "CLANG_MODULES_AUTOLINK" => "YES",
+                                "ENABLE_BITCODE" => "NO"
+                                }
 end

--- a/SensorbergSDK.podspec
+++ b/SensorbergSDK.podspec
@@ -25,10 +25,9 @@ Pod::Spec.new do |s|
 
   s.requires_arc            = true
 
-  s.xcconfig                = { "OTHER_LDFLAGS" => "$(inherited) -ObjC -read_only_relocs suppress",
+  s.xcconfig                = { "OTHER_LDFLAGS" => "$(inherited) -ObjC",
                                 "GCC_PREPROCESSOR_DEFINITIONS" => %{$(inherited) SENSORBERGSDK_VERSION="@\\"#{s.version}\\""},
                                 "CLANG_ENABLE_MODULES" => "YES",
-                                "CLANG_MODULES_AUTOLINK" => "YES",
-                                "ENABLE_BITCODE" => "NO"
+                                "CLANG_MODULES_AUTOLINK" => "YES"
                                 }
 end

--- a/SensorbergSDK.xcconfig
+++ b/SensorbergSDK.xcconfig
@@ -1,5 +1,0 @@
-SENSORBERGSDK_VERSION_STRING = 0.7.9
-GCC_PREPROCESSOR_DEFINITIONS = $(inherited) SENSORBERGSDK_VERSION="@\""$(SENSORBERGSDK_VERSION_STRING)"\""
-OTHER_LDFLAGS = $(inherited) -ObjC -framework CoreBluetooth -framework CoreGraphics -framework CoreLocation -framework Foundation -framework MobileCoreServices -framework Security -framework SystemConfiguration -read_only_relocs suppress
-CLANG_ENABLE_MODULES = YES
-CLANG_MODULES_AUTOLINK = YES


### PR DESCRIPTION
@tagyro Do you think we can safely remove the -read_only_relocs suppress linker flag? This would solve the bitcode problem.

I would rather remove that read_only_relocs falg than force everyone to turn off bitcode...

I also removed the xcconfig file which was not needed nor updated since 1.7.9