### PR TITLE
iOS 7 compat (for 1.0.4+)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ Documentation/
 SensorbergSDK-*/
 
 Example/Pods/*
+Podfile.lock

--- a/SensorbergSDK.podspec
+++ b/SensorbergSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = "SensorbergSDK"
-  s.version                 = "1.0.6"
+  s.version                 = "1.0.7"
   s.platform                = :ios, "7.0"
   s.summary                 = "iOS SDK for handling iBeacon technology via the Sensorberg Beacon Management Platform."
   s.homepage                = "https://github.com/sensorberg-dev/ios-sdk"

--- a/SensorbergSDK/SBSDKDeviceID.m
+++ b/SensorbergSDK/SBSDKDeviceID.m
@@ -78,10 +78,8 @@ NSString *const SBSDKDeviceIDUserDefaultsDomain = @"com.sensorberg.sdk.ios.userd
     NSString *bundleDisplayName = [bundle objectForInfoDictionaryKey:@"CFBundleDisplayName"];
     NSString *bundleIdentifier = [bundle objectForInfoDictionaryKey:@"CFBundleIdentifier"];
     NSString *bundleVersion = [bundle objectForInfoDictionaryKey:@"CFBundleVersion"];
-
-    NSOperatingSystemVersion osVersion = [[NSProcessInfo processInfo] operatingSystemVersion];
     
-    NSString *iosVersion = [NSString stringWithFormat:@"iOS %lu.%lu.%lu", (unsigned long)osVersion.majorVersion, (unsigned long)osVersion.minorVersion, (unsigned long)osVersion.patchVersion];
+    NSString *iosVersion = [NSString stringWithFormat:@"iOS %@", [UIDevice currentDevice].systemVersion];
 
     NSString *sdkString = [NSString stringWithFormat:@"Sensorberg SDK %@", SBSDKSensorbergSDKVersionString];
 

--- a/SensorbergSDK/SBSDKManager.m
+++ b/SensorbergSDK/SBSDKManager.m
@@ -38,7 +38,7 @@
 #import "SBSDKDeviceID.h"
 #import "SBSDKMacros.h"
 
-#define OS_VERSION [[NSProcessInfo processInfo] operatingSystemVersion].majorVersion
+#define OS_VERSION [[UIDevice currentDevice].systemVersion componentsSeparatedByString:@"."][0].integerValue
 
 #pragma mark -
 

--- a/SensorbergSDK/SBSDKManager.m
+++ b/SensorbergSDK/SBSDKManager.m
@@ -38,7 +38,7 @@
 #import "SBSDKDeviceID.h"
 #import "SBSDKMacros.h"
 
-#define OS_VERSION [[UIDevice currentDevice].systemVersion componentsSeparatedByString:@"."][0].integerValue
+#define OS_VERSION [[[UIDevice currentDevice].systemVersion componentsSeparatedByString:@"."] firstObject].integerValue
 
 #pragma mark -
 

--- a/SensorbergSDK/SensorbergSDK+Version.h
+++ b/SensorbergSDK/SensorbergSDK+Version.h
@@ -24,4 +24,4 @@
 //  THE SOFTWARE.
 //
 
-static NSString *const SBSDKSensorbergSDKVersionString = @"1.0.4";
+static NSString *const SBSDKSensorbergSDKVersionString = @"1.0.7";


### PR DESCRIPTION
With 1.0.4 the iOS 7 compatability was broken because ```[[NSProcessInfo processInfo] operatingSystemVersion].majorVersion``` is only available in iOS >= 8.

```[[NSProcessInfo processInfo] operatingSystemVersion].majorVersion``` has been replaced ```[[UIDevice currentDevice].systemVersion componentsSeparatedByString:@"."][0].integerValue```