### PR TITLE
make sdk compile on xcode 6

### DIFF
--- a/SensorbergSDK/SBSDKManager.m
+++ b/SensorbergSDK/SBSDKManager.m
@@ -38,7 +38,7 @@
 #import "SBSDKDeviceID.h"
 #import "SBSDKMacros.h"
 
-#define OS_VERSION [[[UIDevice currentDevice].systemVersion componentsSeparatedByString:@"."] firstObject].integerValue
+#define OS_VERSION [[[[UIDevice currentDevice].systemVersion componentsSeparatedByString:@"."] firstObject] integerValue]
 
 #pragma mark -
 


### PR DESCRIPTION
property syntax cannot be used with variables of generic id type